### PR TITLE
Always define the User-Agent header

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "http-get",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "repo": "clibs/http-get.c",
   "description": "Simple HTTP GET requests backed by libcurl",
   "keywords": [

--- a/src/http-get.c
+++ b/src/http-get.c
@@ -55,6 +55,7 @@ http_get_response_t *http_get_shared(const char *url, CURLSH *share) {
   curl_easy_setopt(req, CURLOPT_FOLLOWLOCATION, 1);
   curl_easy_setopt(req, CURLOPT_WRITEFUNCTION, http_get_cb);
   curl_easy_setopt(req, CURLOPT_WRITEDATA, (void *) res);
+  curl_easy_setopt(req, CURLOPT_USERAGENT, "http-get.c/"HTTP_GET_VERSION);
 
   int c = curl_easy_perform(req);
 

--- a/src/http-get.h
+++ b/src/http-get.h
@@ -14,7 +14,7 @@
 #include <unistd.h>
 #endif
 
-#define HTTP_GET_VERSION "0.1.0"
+#define HTTP_GET_VERSION "0.3.0"
 
 typedef struct {
   char *data;

--- a/test/test.c
+++ b/test/test.c
@@ -23,6 +23,16 @@ int main(int argc, char **argv) {
       assert(200 == res->status);
       http_get_free(res);
     });
+
+    it("should work when the User-Agent header is mandatory", {
+      http_get_response_t *res = http_get("https://api.github.com/repos/clibs/clib/releases/latest");
+      assert(res);
+      assert(res->data);
+      assert(res->ok);
+      assert(200 == res->status);
+      http_get_free(res);
+    });
+
   });
 
   describe("http_get_file", {


### PR DESCRIPTION
There are cases when the `User-Agent` header is mandatory, for example GitHub API requires it, otherwise it'll return 403. I think this change won't cause any break in existing packages relying on `http-get.c`.

For example `http_get("https://api.github.com/repos/clibs/clib/releases/latest")` will return 403 without the `CURLOPT_USERAGENT` option set.