### PR TITLE
Use the correct clib install path/name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@
 
   Install with [clib(1)](https://github.com/clibs/clib):
 
-    $ clib install stephenmathieson/http-get.c
+    $ clib install http-get.c
 
 ## API
 


### PR DESCRIPTION
I believe the username can be omitted, since this is a "default" library.