### PR TITLE
Compilation fails with unknown type name 'size_t' on Windows

### DIFF
--- a/src/http-get.h
+++ b/src/http-get.h
@@ -10,9 +10,7 @@
 #ifndef HTTP_GET_H
 #define HTTP_GET_H 1
 
-#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
-#include <unistd.h>
-#endif
+#include <stdlib.h>
 
 #define HTTP_GET_VERSION "0.3.0"
 


### PR DESCRIPTION
[Here](https://github.com/clibs/clib/pull/245/checks?check_run_id=1737188378#step:4:307) the compilation fails, because `size_t` is not defined. Probably it worked elsewhere because it was included somewhere previously.

I'm not sure about this though:

```c
#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
#include <unistd.h>
#endif
```

I think it can be simply replaced by `#include <stdlib.h>` and will work on every platform.